### PR TITLE
docs: clarify compatibility with logit/prob-outcome segmentation models Clarify #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 </div>
 
-**RankSEG** is a **plug-and-play** post-processing module that improves segmentation results during inference. It works with **ANY pre-trained segmentation model** (DeepLab, SegFormer, UPerNet, etc.) without any retraining or fine-tuning.
+**RankSEG** is a **plug-and-play** post-processing module that improves segmentation results during inference. It works with **ANY pre-trained logit/prob-outcome segmentation model** (SAM, DeepLab, SegFormer, UPerNet, etc.) without any retraining or fine-tuning.
 
 Instead of using simple `thresholding` or `argmax` (which don't care about Dice/IoU scores), RankSEG directly optimizes for these metrics - giving you better results without any extra training.
 

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -56,7 +56,7 @@ The above code handles **99% of semantic segmentation use cases** where we have 
 
 **Key Benefits:**
 
-- ✅ **No retraining required** - Works with any pre-trained segmentation model
+- ✅ **No retraining required** - Works with any pre-trained logit/prob-outcome segmentation model
 - ✅ **Metric-aware** - Directly optimizes for your target metric (Dice, IoU, or Accuracy)
 - ✅ **Statistically consistent** - Theoretically guaranteed to improve performance
 - ✅ **Easy integration** - Just 2 lines of code to add to your inference pipeline
@@ -349,7 +349,7 @@ A: Yes! For binary segmentation, set your ``probs`` shape to ``(batch, 1, *image
 
 **Q: Does RankSEG require retraining my model?**
 
-A: No! RankSEG is a post-processing method that works with any pre-trained segmentation model. Simply apply it to your model's probability outputs during inference.
+A: No! RankSEG is a post-processing method that works with any pre-trained logit/prob-outcome segmentation model. Simply apply it to your model's probability outputs during inference.
 
 ----
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -60,7 +60,7 @@ Key Properties
     * - **🎯 Metric-Optimized**
       - Directly optimizes for Dice or IoU metrics instead of using generic ad-hoc `argmax` during inference.
     * - **🔌 Plug-and-Play**
-      - Works with ANY pre-trained segmentation model without retraining
+      - Works with ANY pre-trained logit/prob-outcome segmentation model without retraining
     * - **⚡ Efficient Solvers**
       - Multiple solver options (BA, TRNA, RMA) for different speed-accuracy trade-offs
     * - **🧩 Flexible Tasks**


### PR DESCRIPTION
Clarify #7 
- Updated README, getting started guide, and index to specify "logit/prob-outcome segmentation model" instead of just "segmentation model"
- Added SAM as an example in the README description
- Clarified in FAQ that RankSEG works with models that output probabilities or logits
- Ensures users understand RankSEG is compatible with both traditional models (DeepLab, SegFormer) and prompt-based models (SAM)
