### PR TITLE
Add Hugging Face Transformers postprocessing integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ preds = rankseg.predict(probs)
 >
 > Official PyTorch integration:
 > [Docs](https://rankseg.readthedocs.io/en/latest/integrations_pytorch.html) · [Example](https://github.com/rankseg/rankseg/blob/main/examples/pytorch_native_rankseg.py)
+>
+> Hugging Face Transformers integration:
+> [Notebook](./notebooks/rankseg_with_transformers.ipynb) · [Colab](https://colab.research.google.com/github/Leev1s/rankseg/blob/feat/transformers-adapter/notebooks/rankseg_with_transformers.ipynb)
 
 
 ## 🔌 Official Integrations
@@ -80,8 +83,8 @@ These are the maintained integration entry points documented by this repository.
 
 | Path | Status | Entry |
 | :--- | :---: | :--- |
-| **PyTorch Native** | **Ready** | [Docs](https://rankseg.readthedocs.io/en/latest/integrations_pytorch.html) · [Example](https://github.com/rankseg/rankseg/blob/main/examples/pytorch_native_rankseg.py) |
-| **Transformers** | Planned | Official integration guide in progress |
+| **PyTorch Native** | **Ready** | [Docs](https://rankseg.readthedocs.io/en/latest/integrations_pytorch.html) · [Example](./examples/pytorch_native_rankseg.py) |
+| **Transformers** | **Ready** | [Docs](https://rankseg.readthedocs.io/en/latest/integrations_transformers.html) · [Example](./examples/transformers_rankseg.py) |
 <!-- | **MMSegmentation** | Planned | Official integration guide in progress | -->
 
 ## 🌐 External Integrations

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ preds = rankseg.predict(probs)
 > [Docs](https://rankseg.readthedocs.io/en/latest/integrations_pytorch.html) · [Example](https://github.com/rankseg/rankseg/blob/main/examples/pytorch_native_rankseg.py)
 >
 > Hugging Face Transformers integration:
-> [Notebook](./notebooks/rankseg_with_transformers.ipynb) · [Colab](https://colab.research.google.com/github/Leev1s/rankseg/blob/feat/transformers-adapter/notebooks/rankseg_with_transformers.ipynb)
+> [Notebook](./notebooks/rankseg_with_transformers.ipynb) · [Colab](https://colab.research.google.com/github/rankseg/rankseg/blob/main/notebooks/rankseg_with_transformers.ipynb)
 
 
 ## 🔌 Official Integrations

--- a/README_zh.md
+++ b/README_zh.md
@@ -75,7 +75,7 @@ preds = rankseg.predict(probs)
 > [Docs](https://rankseg.readthedocs.io/en/latest/integrations_pytorch.html) · [Example](./examples/pytorch_native_rankseg.py)
 >
 > Transformers 集成路径：
-> [Notebook](./notebooks/rankseg_with_transformers.ipynb) · [Colab](https://colab.research.google.com/github/Leev1s/rankseg/blob/feat/transformers-adapter/notebooks/rankseg_with_transformers.ipynb)
+> [Notebook](./notebooks/rankseg_with_transformers.ipynb) · [Colab](https://colab.research.google.com/github/rankseg/rankseg/blob/main/notebooks/rankseg_with_transformers.ipynb)
 
 ## 🔌 官方集成路径
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -72,7 +72,10 @@ preds = rankseg.predict(probs)
 > [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1c2znXP7_yt_9MrE75p-Ag82LHz-WfKq-?usp=sharing)
 >
 > 官方 PyTorch 集成路径：
-> [Docs](https://rankseg.readthedocs.io/en/latest/integrations_pytorch.html) · [Example](https://github.com/rankseg/rankseg/blob/main/examples/pytorch_native_rankseg.py)
+> [Docs](https://rankseg.readthedocs.io/en/latest/integrations_pytorch.html) · [Example](./examples/pytorch_native_rankseg.py)
+>
+> Transformers 集成路径：
+> [Notebook](./notebooks/rankseg_with_transformers.ipynb) · [Colab](https://colab.research.google.com/github/Leev1s/rankseg/blob/feat/transformers-adapter/notebooks/rankseg_with_transformers.ipynb)
 
 ## 🔌 官方集成路径
 
@@ -80,9 +83,8 @@ preds = rankseg.predict(probs)
 
 | 路径 | 状态 | 入口 |
 | :--- | :---: | :--- |
-| **PyTorch Native** | **Ready** | [Docs](https://rankseg.readthedocs.io/en/latest/integrations_pytorch.html) · [Example](https://github.com/rankseg/rankseg/blob/main/examples/pytorch_native_rankseg.py) |
-| **Segment Anything (SAM)** | Planned | 官方集成指南编写中 |
-| **MMSegmentation** | Planned | 官方集成指南编写中 |
+| **PyTorch Native** | **Ready** | [Docs](https://rankseg.readthedocs.io/en/latest/integrations_pytorch.html) · [Example](./examples/pytorch_native_rankseg.py) |
+| **Transformers** | **Ready** | [Docs](https://rankseg.readthedocs.io/en/latest/integrations_transformers.html) · [Example](./examples/transformers_rankseg.py) |
 
 ## 🌐 外部集成路径
 

--- a/doc/source/API.rst
+++ b/doc/source/API.rst
@@ -13,6 +13,8 @@ Module Interface
 .. autoapisummary::
 
    rankseg.RankSEG
+   rankseg.transformers.postprocess
+   rankseg.transformers.restore_semantic_probs
 
 
 Algorithms

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -15,6 +15,9 @@ The first maintained integration path is ``PyTorch Native``, which is the
 recommended starting point for users who already have a PyTorch semantic-
 segmentation model and want to replace ``argmax`` with RankSEG.
 
+If you already run Hugging Face semantic-segmentation models through
+``processor -> model -> outputs``, start with :doc:`integrations_transformers`.
+
 Installation
 ------------
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -188,7 +188,7 @@ Learn More
       :link: integrations
       :link-type: doc
 
-      Maintained integration guides for PyTorch and future framework paths
+      Maintained integration guides for PyTorch and Transformers
 
    .. grid-item-card:: 📚 API Reference
       :link: API

--- a/doc/source/integrations.rst
+++ b/doc/source/integrations.rst
@@ -12,6 +12,7 @@ Available integrations
    :maxdepth: 1
 
    integrations_pytorch
+   integrations_transformers
    integrations_paddleseg
 
 Guiding principle
@@ -23,6 +24,6 @@ framework they already use.
 Solver details such as ``RMA`` remain part of the recommended configuration
 inside each integration page, rather than the top-level navigation label.
 
-At the moment, ``PyTorch Native`` is the main first-party maintained entry
-point documented here, while ``PaddleSeg`` is provided as an
+At the moment, ``PyTorch Native`` and ``Transformers`` are the first-party
+maintained entry points documented here, while ``PaddleSeg`` is provided as an
 external/community-maintained path.

--- a/doc/source/integrations_transformers.rst
+++ b/doc/source/integrations_transformers.rst
@@ -101,4 +101,4 @@ Notebook and Colab demo
 
 - Example script: `examples/transformers_rankseg.py <https://github.com/rankseg/rankseg/blob/main/examples/transformers_rankseg.py>`_
 - Notebook: `notebooks/rankseg_with_transformers.ipynb <https://github.com/rankseg/rankseg/blob/main/notebooks/rankseg_with_transformers.ipynb>`_
-- Colab: `Open the notebook in Colab <https://colab.research.google.com/github/Leev1s/rankseg/blob/feat/transformers-adapter/notebooks/rankseg_with_transformers.ipynb>`_
+- Colab: `Open the notebook in Colab <https://colab.research.google.com/github/rankseg/rankseg/blob/main/notebooks/rankseg_with_transformers.ipynb>`_

--- a/doc/source/integrations_transformers.rst
+++ b/doc/source/integrations_transformers.rst
@@ -1,0 +1,104 @@
+Transformers
+============
+
+This page documents the official RankSEG integration path for Hugging Face
+``transformers`` semantic-segmentation outputs.
+
+If you already run inference manually through a ``processor -> model ->
+outputs`` workflow, this is the recommended entry point.
+
+Recommended entry point
+-----------------------
+
+.. code-block:: python
+
+   from rankseg.transformers import postprocess
+
+The main helper is:
+
+.. code-block:: python
+
+   postprocess(outputs, *, model=None, target_sizes, rankseg_kwargs=None)
+
+Its role is intentionally narrow:
+
+- restore semantic probabilities from supported Hugging Face output families;
+- resize them to the original image size when needed;
+- apply ``RankSEG`` as the final post-processing step.
+
+Minimal integration
+-------------------
+
+The standard Hugging Face inference structure stays the same. The only
+integration change happens after ``outputs = model(**inputs)``.
+
+.. code-block:: python
+
+   from transformers import SegformerImageProcessor, AutoModelForSemanticSegmentation
+   from rankseg.transformers import postprocess
+   from PIL import Image
+   import requests
+
+   processor = SegformerImageProcessor.from_pretrained("mattmdjaga/segformer_b2_clothes")
+   model = AutoModelForSemanticSegmentation.from_pretrained("mattmdjaga/segformer_b2_clothes")
+
+   image = Image.open(requests.get("https://plus.unsplash.com/premium_photo-1673210886161-bfcc40f54d1f?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8cGVyc29uJTIwc3RhbmRpbmd8ZW58MHx8MHx8&w=1000&q=80", stream=True).raw)
+   inputs = processor(images=image, return_tensors="pt")
+   outputs = model(**inputs)
+
+   preds = postprocess(
+       outputs,
+       target_sizes=image.size[::-1],
+       rankseg_kwargs={"metric": "dice"},
+   )
+
+For supported output families, ``postprocess(...)`` replaces the final
+``argmax``-style decision step while preserving the surrounding Hugging Face
+inference code.
+
+Low-level helper
+----------------
+
+The module also exposes:
+
+.. code-block:: python
+
+   from rankseg.transformers import restore_semantic_probs
+
+``restore_semantic_probs(...)`` is a lower-level helper for users who want the
+restored semantic probability map directly. It may be imported and used
+directly, but it is not the primary recommended API.
+
+Supported output families
+-------------------------
+
+The current helper supports the main semantic-segmentation output families used
+by ``transformers``:
+
+- ``outputs.logits``
+- ``outputs.class_queries_logits`` + ``outputs.masks_queries_logits``
+- ``outputs.logits`` + ``outputs.pred_masks``
+- ``outputs.semantic_seg``
+
+When a branch requires model-specific handling, pass ``model=...`` so the
+helper can follow the corresponding official post-processing behavior.
+
+Current exclusions
+------------------
+
+The simplified API does not currently support:
+
+- outputs with ``patch_offsets`` that require official patch-merge logic;
+- tuple-style outputs such as ``return_dict=False`` returns;
+- custom unstructured outputs from ``trust_remote_code=True`` models;
+- SegGPT-style ``pred_masks`` semantic reconstruction.
+
+These cases should fail explicitly rather than silently using an incorrect
+semantic restoration path.
+
+Notebook and Colab demo
+-----------------------
+
+- Example script: `examples/transformers_rankseg.py <https://github.com/rankseg/rankseg/blob/main/examples/transformers_rankseg.py>`_
+- Notebook: `notebooks/rankseg_with_transformers.ipynb <https://github.com/rankseg/rankseg/blob/main/notebooks/rankseg_with_transformers.ipynb>`_
+- Colab: `Open the notebook in Colab <https://colab.research.google.com/github/Leev1s/rankseg/blob/feat/transformers-adapter/notebooks/rankseg_with_transformers.ipynb>`_

--- a/examples/transformers_rankseg.py
+++ b/examples/transformers_rankseg.py
@@ -1,0 +1,84 @@
+"""Official Transformers integration example.
+
+This script shows the minimal insertion point for RankSEG in a standard
+Hugging Face semantic-segmentation inference pipeline.
+
+Typical workflow:
+1. Load a segmentation processor and model from `transformers`.
+2. Run the usual `processor -> model -> outputs` inference path.
+3. Replace manual post-processing with `rankseg.transformers.postprocess`.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import requests
+import torch.nn.functional as F
+from PIL import Image
+from transformers import AutoModelForSemanticSegmentation, SegformerImageProcessor
+
+from rankseg.transformers import postprocess
+
+
+def predict_with_rankseg(
+    outputs: object,
+    image_size: tuple[int, int],
+    *,
+    metric: str = "dice",
+):
+    """Post-process Hugging Face segmentation outputs with RankSEG."""
+    return postprocess(
+        outputs,
+        target_sizes=image_size[::-1],
+        rankseg_kwargs={"metric": metric},
+    )
+
+
+def main() -> None:
+    processor = SegformerImageProcessor.from_pretrained("mattmdjaga/segformer_b2_clothes")
+    model = AutoModelForSemanticSegmentation.from_pretrained("mattmdjaga/segformer_b2_clothes")
+
+    url = (
+        "https://plus.unsplash.com/premium_photo-1673210886161-bfcc40f54d1f"
+        "?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8cGVyc29uJTIwc3RhbmRpbmd8ZW58MHx8MHx8&w=1000&q=80"
+    )
+    image = Image.open(requests.get(url, stream=True).raw)
+    inputs = processor(images=image, return_tensors="pt")
+
+    outputs = model(**inputs)
+    logits = outputs.logits.cpu()
+    upsampled_logits = F.interpolate(
+        logits,
+        size=image.size[::-1],
+        mode="bilinear",
+        align_corners=False,
+    )
+    baseline_pred = upsampled_logits.argmax(dim=1)[0]
+    rankseg_pred = predict_with_rankseg(outputs, image.size)[0].cpu()
+
+    print("Image size:    ", image.size[::-1])
+    print("Logits shape:  ", tuple(outputs.logits.shape))
+    print("Baseline shape:", tuple(baseline_pred.shape))
+    print("RankSEG shape: ", tuple(rankseg_pred.shape))
+    print()
+    print("Integration summary:")
+    print("- Keep the standard Hugging Face processor and model unchanged.")
+    print("- Run the usual processor -> model -> outputs inference path.")
+    print("- Replace manual argmax post-processing with rankseg.transformers.postprocess(...).")
+    print("- Pass target_sizes as the original image size in (H, W) order.")
+
+    fig, axes = plt.subplots(1, 3, figsize=(15, 5))
+    axes[0].imshow(image)
+    axes[0].set_title("Input image")
+    axes[1].imshow(baseline_pred)
+    axes[1].set_title("Baseline argmax")
+    axes[2].imshow(rankseg_pred)
+    axes[2].set_title("RankSEG postprocess")
+    for ax in axes:
+        ax.axis("off")
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/notebooks/rankseg_with_transformers.ipynb
+++ b/notebooks/rankseg_with_transformers.ipynb
@@ -1,0 +1,298 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "161390a4",
+   "metadata": {},
+   "source": [
+    "# RankSEG with Hugging Face Transformers\n",
+    "\n",
+    "This notebook demonstrates a focused Colab integration path for applying **RankSEG** on top of a standard Hugging Face semantic segmentation workflow.\n",
+    "\n",
+    "## What RankSEG changes\n",
+    "\n",
+    "RankSEG does not replace model inference. It replaces the final decision step that turns dense per-class scores into a discrete segmentation map. In place of plain `argmax`, RankSEG applies a metric-aware post-processing procedure designed to improve the final mask with respect to overlap-based objectives such as **Dice**.\n",
+    "\n",
+    "## What this notebook covers\n",
+    "\n",
+    "1. Run the original `jonathandinu/face-parsing` example as a baseline.\n",
+    "2. Keep the same preprocessing, model loading, and forward pass.\n",
+    "3. Swap only the last post-processing step for `rankseg.transformers.postprocess(...)`.\n",
+    "4. Compare the baseline output and the RankSEG result side by side.\n",
+    "\n",
+    "The emphasis is deliberate: this notebook is not about introducing a new inference stack. It is about showing that, for supported `transformers` segmentation outputs, RankSEG can be inserted as a narrow post-processing layer with minimal disruption to the surrounding code.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0770acb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Colab setup\n",
+    "%pip install -q uv\n",
+    "!uv pip install git+https://github.com/Leev1s/rankseg.git@feat/transformers-adapter\n",
+    "!uv pip install -q transformers pillow requests matplotlib\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c1d00d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gc\n",
+    "import torch\n",
+    "\n",
+    "def cleanup_runtime(*names):\n",
+    "    \"\"\"Release named globals and clear CUDA cache between notebook stages.\"\"\"\n",
+    "    for name in names:\n",
+    "        globals().pop(name, None)\n",
+    "\n",
+    "    gc.collect()\n",
+    "\n",
+    "    if torch.cuda.is_available():\n",
+    "        torch.cuda.empty_cache()\n",
+    "\n",
+    "    gc.collect()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b465a36",
+   "metadata": {},
+   "source": [
+    "## 1. Official Hugging Face baseline\n",
+    "\n",
+    "The next code cell follows the original `jonathandinu/face-parsing` usage pattern closely. The steps are conventional and familiar:\n",
+    "\n",
+    "- preprocess the image with `SegformerImageProcessor`\n",
+    "- run the model forward pass\n",
+    "- resize logits back to the original image resolution\n",
+    "- obtain the final label map with `argmax`\n",
+    "\n",
+    "Reference model card: [jonathandinu/face-parsing](https://huggingface.co/jonathandinu/face-parsing)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41c77226",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from torch import nn\n",
+    "from transformers import SegformerImageProcessor, SegformerForSemanticSegmentation\n",
+    "\n",
+    "from PIL import Image\n",
+    "import matplotlib.pyplot as plt\n",
+    "import requests\n",
+    "\n",
+    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+    "\n",
+    "# load models\n",
+    "image_processor = SegformerImageProcessor.from_pretrained(\"jonathandinu/face-parsing\")\n",
+    "model = SegformerForSemanticSegmentation.from_pretrained(\"jonathandinu/face-parsing\")\n",
+    "model.to(device)\n",
+    "\n",
+    "# expects a PIL.Image or torch.Tensor\n",
+    "url = \"https://images.unsplash.com/photo-1539571696357-5a69c17a67c6\"\n",
+    "image = Image.open(requests.get(url, stream=True).raw)\n",
+    "\n",
+    "# run inference on image\n",
+    "inputs = image_processor(images=image, return_tensors=\"pt\").to(device)\n",
+    "outputs = model(**inputs)\n",
+    "logits = outputs.logits  # shape (batch_size, num_labels, ~height/4, ~width/4)\n",
+    "\n",
+    "# resize output to match input image dimensions\n",
+    "upsampled_logits = nn.functional.interpolate(logits,\n",
+    "                size=image.size[::-1], # H x W\n",
+    "                mode='bilinear',\n",
+    "                align_corners=False)\n",
+    "\n",
+    "# get label masks\n",
+    "labels = upsampled_logits.argmax(dim=1)[0]\n",
+    "\n",
+    "# move to CPU to visualize in matplotlib\n",
+    "labels_viz = labels.cpu().numpy()\n",
+    "plt.imshow(labels_viz)\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "382024fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# keep the baseline visualization, and release the heavier tensors before the RankSEG stage\n",
+    "cleanup_runtime(\n",
+    "    \"model\",\n",
+    "    \"image_processor\",\n",
+    "    \"image\",\n",
+    "    \"inputs\",\n",
+    "    \"outputs\",\n",
+    "    \"logits\",\n",
+    "    \"upsampled_logits\",\n",
+    "    \"labels\",\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5cc60ef2",
+   "metadata": {},
+   "source": [
+    "## 2. RankSEG drop-in version\n",
+    "\n",
+    "This cell intentionally repeats the same inference structure. The processor, model, image preparation, and forward pass all remain unchanged.\n",
+    "\n",
+    "The integration point is a single hand-off after `outputs = model(**inputs)`. At that point, `rankseg.transformers.postprocess(...)` takes over the final stage of the pipeline. For supported Hugging Face segmentation outputs, it restores semantic probabilities according to the corresponding `transformers` post-processing behavior and then applies RankSEG at the original image resolution.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d80b42dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from torch import nn\n",
+    "from transformers import SegformerImageProcessor, SegformerForSemanticSegmentation\n",
+    "from rankseg.transformers import postprocess\n",
+    "\n",
+    "from PIL import Image\n",
+    "import matplotlib.pyplot as plt\n",
+    "import requests\n",
+    "\n",
+    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+    "\n",
+    "# load models\n",
+    "image_processor = SegformerImageProcessor.from_pretrained(\"jonathandinu/face-parsing\")\n",
+    "model = SegformerForSemanticSegmentation.from_pretrained(\"jonathandinu/face-parsing\")\n",
+    "model.to(device)\n",
+    "\n",
+    "# expects a PIL.Image or torch.Tensor\n",
+    "url = \"https://images.unsplash.com/photo-1539571696357-5a69c17a67c6\"\n",
+    "image = Image.open(requests.get(url, stream=True).raw)\n",
+    "\n",
+    "# run inference on image\n",
+    "inputs = image_processor(images=image, return_tensors=\"pt\").to(device)\n",
+    "outputs = model(**inputs)\n",
+    "\n",
+    "# get label masks\n",
+    "rankseg_labels = postprocess(\n",
+    "    outputs,\n",
+    "    target_sizes=image.size[::-1],\n",
+    "    rankseg_kwargs={\"metric\": \"dice\"},\n",
+    ")[0]\n",
+    "\n",
+    "# move to CPU to visualize in matplotlib\n",
+    "rankseg_labels_viz = rankseg_labels.cpu().numpy()\n",
+    "plt.imshow(rankseg_labels_viz)\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a8f3168",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# keep the RankSEG visualization for comparison, and release the second-stage tensors\n",
+    "cleanup_runtime(\n",
+    "    \"model\",\n",
+    "    \"image_processor\",\n",
+    "    \"inputs\",\n",
+    "    \"outputs\",\n",
+    "    \"rankseg_labels\",\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "751e548d",
+   "metadata": {},
+   "source": [
+    "## 3. Visual comparison\n",
+    "\n",
+    "The comparison below is meant to answer a narrow question: **what changes when only the final post-processing step is replaced, while everything upstream remains the same?**\n",
+    "\n",
+    "The four panels show:\n",
+    "\n",
+    "1. the input image\n",
+    "2. the official Hugging Face `argmax` baseline\n",
+    "3. the RankSEG post-processed result\n",
+    "4. a binary difference map between the two outputs\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8d199cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "difference_viz = (labels_viz != rankseg_labels_viz).astype(\"uint8\")\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 4, figsize=(20, 5))\n",
+    "\n",
+    "axes[0].imshow(image)\n",
+    "axes[0].set_title(\"Input image\")\n",
+    "axes[1].imshow(labels_viz)\n",
+    "axes[1].set_title(\"Baseline argmax\")\n",
+    "axes[2].imshow(rankseg_labels_viz)\n",
+    "axes[2].set_title(\"RankSEG postprocess\")\n",
+    "axes[3].imshow(difference_viz, cmap=\"gray\", vmin=0, vmax=1)\n",
+    "axes[3].set_title(\"Difference map\")\n",
+    "\n",
+    "for ax in axes:\n",
+    "    ax.axis(\"off\")\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ebac8982",
+   "metadata": {},
+   "source": [
+    "## Takeaway\n",
+    "\n",
+    "This notebook illustrates the current integration contract between RankSEG and Hugging Face `transformers` in its simplest form:\n",
+    "\n",
+    "- keep the standard preprocessing and forward pass\n",
+    "- treat model `outputs` as the integration boundary\n",
+    "- call `rankseg.transformers.postprocess(...)` with the original `target_sizes`\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/rankseg_with_transformers.ipynb
+++ b/notebooks/rankseg_with_transformers.ipynb
@@ -279,18 +279,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/rankseg_with_transformers.ipynb
+++ b/notebooks/rankseg_with_transformers.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "# Colab setup\n",
     "%pip install -q uv\n",
-    "!uv pip install git+https://github.com/Leev1s/rankseg.git@feat/transformers-adapter\n",
+    "!uv pip install -U rankseg\n",
     "!uv pip install -q transformers pillow requests matplotlib\n"
    ]
   },

--- a/rankseg/README.md
+++ b/rankseg/README.md
@@ -7,10 +7,10 @@ This directory contains the Python package modules behind the public `rankseg` A
 - `_rankseg.py`: defines the `RankSEG` class and the main prediction entry point
 - `_rankseg_algo.py`: lower-level solver implementations used by `RankSEG`
 - `distribution.py`: probability-distribution utilities used by the algorithms
-- `transformers.py`: Hugging Face Transformers compatibility helper for restoring semantic probabilities and applying `RankSEG`
+- `transformers.py`: Hugging Face Transformers compatibility helper for restoring semantic probabilities and post-processing with `RankSEG`
 
 ## Import path
 
 ```python
-from rankseg.transformers import rankseg, restore_semantic_probs
+from rankseg.transformers import postprocess, restore_semantic_probs
 ```

--- a/rankseg/README.md
+++ b/rankseg/README.md
@@ -1,0 +1,16 @@
+# RankSEG Package Layout
+
+This directory contains the Python package modules behind the public `rankseg` API.
+
+## Main modules
+
+- `_rankseg.py`: defines the `RankSEG` class and the main prediction entry point
+- `_rankseg_algo.py`: lower-level solver implementations used by `RankSEG`
+- `distribution.py`: probability-distribution utilities used by the algorithms
+- `transformers.py`: Hugging Face Transformers compatibility helper for restoring semantic probabilities and applying `RankSEG`
+
+## Import path
+
+```python
+from rankseg.transformers import rankseg, restore_semantic_probs
+```

--- a/rankseg/transformers.py
+++ b/rankseg/transformers.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import torch
+import torch.nn.functional as F
+
+from ._rankseg import RankSEG
+
+
+def _get_output_value(outputs, name: str):
+    if isinstance(outputs, (tuple, list)):
+        raise ValueError("Tuple-style outputs are not supported. Pass structured outputs with named fields.")
+
+    value = getattr(outputs, name, None)
+    if value is not None:
+        return value
+
+    if isinstance(outputs, Mapping):
+        return outputs.get(name)
+
+    return None
+
+
+def _normalize_target_size(target_sizes, batch_size: int) -> tuple[int, int]:
+    if target_sizes is None:
+        raise ValueError("`target_sizes` is required and must describe the original image size.")
+
+    if isinstance(target_sizes, torch.Tensor):
+        if target_sizes.ndim == 1:
+            target_sizes = tuple(int(v) for v in target_sizes.tolist())
+        elif target_sizes.ndim == 2:
+            target_sizes = [tuple(int(v) for v in row.tolist()) for row in target_sizes]
+        else:
+            raise ValueError("`target_sizes` must be a tuple, list of tuples, or a tensor of shape (2) or (B, 2).")
+
+    if isinstance(target_sizes, Sequence) and not isinstance(target_sizes, (str, bytes)):
+        if len(target_sizes) == 2 and all(not isinstance(v, Sequence) for v in target_sizes):
+            return int(target_sizes[0]), int(target_sizes[1])
+
+        normalized = [tuple(int(v) for v in size) for size in target_sizes]
+        if len(normalized) != batch_size:
+            raise ValueError("`target_sizes` must match the batch size when passing per-sample sizes.")
+        first = normalized[0]
+        if any(size != first for size in normalized[1:]):
+            raise ValueError("Batches with different original image sizes are not supported. Call the helper per sample.")
+        return first
+
+    raise ValueError("`target_sizes` must be a tuple, list of tuples, or a tensor of shape (2) or (B, 2).")
+
+
+def _resize_spatial(tensor: torch.Tensor, target_size: tuple[int, int]) -> torch.Tensor:
+    if tensor.shape[-2:] == target_size:
+        return tensor
+    return F.interpolate(tensor, size=target_size, mode="bilinear", align_corners=False)
+
+
+def _normalize_scores(scores: torch.Tensor) -> torch.Tensor:
+    return scores / scores.sum(dim=1, keepdim=True).clamp_min(1e-12)
+
+
+def _matches_output_class(outputs, class_name: str) -> bool:
+    return type(outputs).__name__ == class_name
+
+
+def _matches_config_class(model, class_name: str) -> bool:
+    return type(getattr(model, "config", None)).__name__ == class_name
+
+
+def restore_semantic_probs(outputs, *, model=None, target_sizes):
+    semantic_seg = _get_output_value(outputs, "semantic_seg")
+    if semantic_seg is not None:
+        if not isinstance(semantic_seg, torch.Tensor):
+            raise TypeError("`outputs.semantic_seg` must be a torch.Tensor.")
+        target_size = _normalize_target_size(target_sizes, semantic_seg.shape[0])
+        semantic_probs = semantic_seg.float().sigmoid()
+        return _resize_spatial(semantic_probs, target_size)
+
+    class_queries_logits = _get_output_value(outputs, "class_queries_logits")
+    masks_queries_logits = _get_output_value(outputs, "masks_queries_logits")
+    patch_offsets = _get_output_value(outputs, "patch_offsets")
+    if class_queries_logits is not None and masks_queries_logits is not None:
+        if patch_offsets is not None:
+            raise ValueError(
+                "Outputs with `patch_offsets` require official patch merge logic and are not supported by this helper."
+            )
+        if not isinstance(class_queries_logits, torch.Tensor) or not isinstance(masks_queries_logits, torch.Tensor):
+            raise TypeError("`class_queries_logits` and `masks_queries_logits` must be torch.Tensor values.")
+        target_size = _normalize_target_size(target_sizes, class_queries_logits.shape[0])
+        if _matches_config_class(model, "Mask2FormerConfig") or _matches_output_class(
+            outputs, "Mask2FormerForUniversalSegmentationOutput"
+        ):
+            masks_queries_logits = F.interpolate(
+                masks_queries_logits.float(), size=(384, 384), mode="bilinear", align_corners=False
+            )
+        else:
+            masks_queries_logits = masks_queries_logits.float()
+        masks_classes = class_queries_logits.float().softmax(dim=-1)[..., :-1]
+        masks_probs = masks_queries_logits.sigmoid()
+        semantic_scores = torch.einsum("bqc,bqhw->bchw", masks_classes, masks_probs)
+        semantic_scores = _resize_spatial(semantic_scores, target_size)
+        return _normalize_scores(semantic_scores)
+
+    logits = _get_output_value(outputs, "logits")
+    pred_masks = _get_output_value(outputs, "pred_masks")
+    if logits is not None and pred_masks is not None:
+        if not isinstance(logits, torch.Tensor) or not isinstance(pred_masks, torch.Tensor):
+            raise TypeError("`logits` and `pred_masks` must be torch.Tensor values.")
+        if model is None:
+            raise ValueError("`model` is required for outputs with both `logits` and `pred_masks`.")
+
+        target_size = _normalize_target_size(target_sizes, logits.shape[0])
+        config_name = type(getattr(model, "config", None)).__name__
+        masks_classes = logits.float().softmax(dim=-1)
+        if config_name != "ConditionalDetrConfig":
+            masks_classes = masks_classes[..., :-1]
+        masks_probs = pred_masks.float().sigmoid()
+        semantic_scores = torch.einsum("bqc,bqhw->bchw", masks_classes, masks_probs)
+        semantic_scores = _resize_spatial(semantic_scores, target_size)
+        return _normalize_scores(semantic_scores)
+
+    if logits is not None:
+        if not isinstance(logits, torch.Tensor):
+            raise TypeError("`outputs.logits` must be a torch.Tensor.")
+        target_size = _normalize_target_size(target_sizes, logits.shape[0])
+        resized_logits = _resize_spatial(logits.float(), target_size)
+        return resized_logits.softmax(dim=1)
+
+    if pred_masks is not None:
+        raise ValueError(
+            "Outputs with only `pred_masks` require model-specific semantic reconstruction and are not supported."
+        )
+
+    raise ValueError("Unsupported outputs structure for semantic probability restoration.")
+
+
+def rankseg(outputs, *, model=None, target_sizes, rankseg_kwargs=None):
+    if rankseg_kwargs is None:
+        rankseg_kwargs = {}
+    elif not isinstance(rankseg_kwargs, dict):
+        raise ValueError("`rankseg_kwargs` must be a dictionary.")
+
+    probs = restore_semantic_probs(outputs, model=model, target_sizes=target_sizes)
+
+    if "output_mode" not in rankseg_kwargs:
+        rankseg_kwargs = {
+            **rankseg_kwargs,
+            "output_mode": "multilabel" if probs.shape[1] == 1 else "multiclass",
+        }
+
+    predictor = RankSEG(**rankseg_kwargs)
+    return predictor.predict(probs)

--- a/rankseg/transformers.py
+++ b/rankseg/transformers.py
@@ -134,7 +134,7 @@ def restore_semantic_probs(outputs, *, model=None, target_sizes):
     raise ValueError("Unsupported outputs structure for semantic probability restoration.")
 
 
-def rankseg(outputs, *, model=None, target_sizes, rankseg_kwargs=None):
+def postprocess(outputs, *, model=None, target_sizes, rankseg_kwargs=None):
     if rankseg_kwargs is None:
         rankseg_kwargs = {}
     elif not isinstance(rankseg_kwargs, dict):

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -1,0 +1,187 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from rankseg.transformers import postprocess, restore_semantic_probs
+
+
+def _model(config_name: str):
+    return SimpleNamespace(config=type(config_name, (), {})())
+
+
+def _assert_probs_sum_to_one(probs: torch.Tensor, *, atol: float = 1e-5) -> None:
+    assert torch.allclose(probs.sum(dim=1), torch.ones_like(probs.sum(dim=1)), atol=atol)
+
+
+def test_restore_semantic_probs_from_logits_resizes_then_softmax():
+    logits = torch.tensor(
+        [[[[2.0, 0.0], [0.0, 2.0]], [[0.0, 2.0], [2.0, 0.0]]]],
+        dtype=torch.float32,
+    )
+    outputs = SimpleNamespace(logits=logits)
+
+    probs = restore_semantic_probs(outputs, target_sizes=(4, 4))
+
+    assert probs.shape == (1, 2, 4, 4)
+    _assert_probs_sum_to_one(probs)
+
+
+def test_restore_semantic_probs_from_query_outputs_normalizes_scores():
+    class_queries_logits = torch.tensor([[[5.0, 1.0, -2.0], [1.0, 4.0, -2.0]]], dtype=torch.float32)
+    masks_queries_logits = torch.tensor(
+        [[[[4.0, 0.0], [0.0, 4.0]], [[0.0, 4.0], [4.0, 0.0]]]],
+        dtype=torch.float32,
+    )
+    outputs = SimpleNamespace(
+        class_queries_logits=class_queries_logits,
+        masks_queries_logits=masks_queries_logits,
+    )
+
+    probs = restore_semantic_probs(outputs, target_sizes=(4, 4))
+
+    assert probs.shape == (1, 2, 4, 4)
+    _assert_probs_sum_to_one(probs)
+
+
+def test_restore_semantic_probs_from_detr_requires_model():
+    outputs = SimpleNamespace(
+        logits=torch.randn(1, 2, 3),
+        pred_masks=torch.randn(1, 2, 2, 2),
+    )
+
+    with pytest.raises(ValueError, match="`model` is required"):
+        restore_semantic_probs(outputs, target_sizes=(4, 4))
+
+
+def test_restore_semantic_probs_from_detr_drops_null_class():
+    outputs = SimpleNamespace(
+        logits=torch.tensor([[[6.0, 1.0, -5.0], [1.0, 6.0, -5.0]]], dtype=torch.float32),
+        pred_masks=torch.tensor(
+            [[[[4.0, 0.0], [0.0, 4.0]], [[0.0, 4.0], [4.0, 0.0]]]],
+            dtype=torch.float32,
+        ),
+    )
+    model = _model("DetrConfig")
+
+    probs = restore_semantic_probs(outputs, model=model, target_sizes=(4, 4))
+
+    assert probs.shape == (1, 2, 4, 4)
+    _assert_probs_sum_to_one(probs)
+
+
+def test_restore_semantic_probs_from_conditional_detr_keeps_all_classes():
+    outputs = SimpleNamespace(
+        logits=torch.tensor([[[5.0, 1.0], [1.0, 5.0]]], dtype=torch.float32),
+        pred_masks=torch.tensor(
+            [[[[4.0, 0.0], [0.0, 4.0]], [[0.0, 4.0], [4.0, 0.0]]]],
+            dtype=torch.float32,
+        ),
+    )
+    model = _model("ConditionalDetrConfig")
+
+    probs = restore_semantic_probs(outputs, model=model, target_sizes=(4, 4))
+
+    assert probs.shape == (1, 2, 4, 4)
+    _assert_probs_sum_to_one(probs)
+
+
+def test_restore_semantic_probs_from_semantic_seg_uses_sigmoid():
+    outputs = SimpleNamespace(semantic_seg=torch.tensor([[[[0.0, 2.0], [-2.0, 0.0]]]], dtype=torch.float32))
+
+    probs = restore_semantic_probs(outputs, target_sizes=(4, 4))
+
+    assert probs.shape == (1, 1, 4, 4)
+    assert float(probs.min()) >= 0.0
+    assert float(probs.max()) <= 1.0
+
+
+def test_restore_semantic_probs_from_mask2former_matches_official_pre_resize():
+    class_queries_logits = torch.tensor([[[6.0, 1.0, -4.0], [1.0, 6.0, -4.0]]], dtype=torch.float32)
+    masks_queries_logits = torch.tensor(
+        [[[[8.0, -8.0], [-8.0, 8.0]], [[-8.0, 8.0], [8.0, -8.0]]]],
+        dtype=torch.float32,
+    )
+    outputs = SimpleNamespace(
+        class_queries_logits=class_queries_logits,
+        masks_queries_logits=masks_queries_logits,
+    )
+
+    probs = restore_semantic_probs(outputs, model=_model("Mask2FormerConfig"), target_sizes=(5, 5))
+
+    expected_masks = F.interpolate(masks_queries_logits, size=(384, 384), mode="bilinear", align_corners=False)
+    expected_scores = torch.einsum(
+        "bqc,bqhw->bchw",
+        class_queries_logits.softmax(dim=-1)[..., :-1],
+        expected_masks.sigmoid(),
+    )
+    expected_scores = F.interpolate(expected_scores, size=(5, 5), mode="bilinear", align_corners=False)
+    expected_probs = expected_scores / expected_scores.sum(dim=1, keepdim=True).clamp_min(1e-12)
+
+    assert probs.shape == (1, 2, 5, 5)
+    assert torch.allclose(probs, expected_probs, atol=1e-5)
+
+
+def test_restore_semantic_probs_from_semantic_seg_matches_sam3_official_order():
+    semantic_seg = torch.tensor([[[[-4.0, 1.0], [2.0, 8.0]]]], dtype=torch.float32)
+    outputs = SimpleNamespace(semantic_seg=semantic_seg)
+
+    probs = restore_semantic_probs(outputs, target_sizes=(4, 5))
+
+    expected = F.interpolate(semantic_seg.sigmoid(), size=(4, 5), mode="bilinear", align_corners=False)
+    old_behavior = F.interpolate(semantic_seg, size=(4, 5), mode="bilinear", align_corners=False).sigmoid()
+
+    assert torch.allclose(probs, expected, atol=1e-6)
+    assert not torch.allclose(probs, old_behavior, atol=1e-6)
+
+
+def test_postprocess_defaults_to_multiclass_for_multi_channel_probs():
+    outputs = SimpleNamespace(
+        logits=torch.tensor(
+            [[[[3.0, 0.0], [0.0, 3.0]], [[0.0, 3.0], [3.0, 0.0]]]],
+            dtype=torch.float32,
+        )
+    )
+
+    preds = postprocess(outputs, target_sizes=(4, 4))
+
+    assert preds.shape == (1, 4, 4)
+
+
+def test_postprocess_defaults_to_multilabel_for_single_channel_probs():
+    outputs = SimpleNamespace(semantic_seg=torch.tensor([[[[2.0, -2.0], [-2.0, 2.0]]]], dtype=torch.float32))
+
+    preds = postprocess(outputs, target_sizes=(4, 4))
+
+    assert preds.shape == (1, 1, 4, 4)
+
+
+def test_restore_semantic_probs_rejects_patch_offsets_path():
+    outputs = SimpleNamespace(
+        class_queries_logits=torch.randn(1, 2, 3),
+        masks_queries_logits=torch.randn(1, 2, 2, 2),
+        patch_offsets=[torch.tensor([0, 0, 1, 1])],
+    )
+
+    with pytest.raises(ValueError, match="patch merge logic"):
+        restore_semantic_probs(outputs, target_sizes=(4, 4))
+
+
+def test_restore_semantic_probs_rejects_tuple_outputs():
+    with pytest.raises(ValueError, match="Tuple-style outputs"):
+        restore_semantic_probs((torch.randn(1, 2, 2, 2),), target_sizes=(4, 4))
+
+
+def test_restore_semantic_probs_rejects_mixed_target_sizes():
+    outputs = SimpleNamespace(logits=torch.randn(2, 2, 2, 2))
+
+    with pytest.raises(ValueError, match="different original image sizes"):
+        restore_semantic_probs(outputs, target_sizes=[(4, 4), (5, 5)])
+
+
+def test_restore_semantic_probs_rejects_pred_masks_only_with_specific_message():
+    outputs = SimpleNamespace(pred_masks=torch.randn(1, 2, 2, 2))
+
+    with pytest.raises(ValueError, match="model-specific semantic reconstruction"):
+        restore_semantic_probs(outputs, target_sizes=(4, 4))


### PR DESCRIPTION
## Summary

This PR adds an official Hugging Face `transformers` integration path to RankSEG for semantic segmentation workflows.

The main goal is to let users keep the standard `processor -> model -> outputs` inference pattern and insert RankSEG at the post-processing boundary.

## What is included

### 1. `rankseg.transformers` integration helper

This PR adds a new compatibility layer at:

- `rankseg.transformers.postprocess(...)`
- `rankseg.transformers.restore_semantic_probs(...)`

The helper restores supported Hugging Face segmentation outputs into semantic probability maps at the original image size, then applies RankSEG as the final post-processing step.

For a runnable demonstration, the README links to this [Colab notebook](https://colab.research.google.com/github/Leev1s/rankseg/blob/feat/transformers-adapter/notebooks/rankseg_with_transformers.ipynb), which shows the Transformers integration end to end.

Supported output families in this PR:

- `outputs.logits`
- `outputs.class_queries_logits + outputs.masks_queries_logits`
- `outputs.logits + outputs.pred_masks`
- `outputs.semantic_seg`

The implementation is intentionally narrow and follows the official `transformers` semantic post-processing behavior for the supported families.

### 2. Official example and notebook

This PR adds:

- `examples/transformers_rankseg.py`
- `notebooks/rankseg_with_transformers.ipynb`

The example script shows the minimal insertion point in a standard Hugging Face inference flow.

The notebook is written as a side-by-side baseline vs. RankSEG integration walkthrough, with the integration hand-off kept explicitly at `outputs = model(**inputs)`.

### 3. Documentation updates

This PR updates the repository documentation so that `Transformers` is now presented as an official integration path alongside `PyTorch Native`.

Changes include:

- README and README_zh updates
- a new `doc/source/integrations_transformers.rst` page
- docs navigation updates in `index.rst`, `getting_started.rst`, and `integrations.rst`
- API docs entries for `rankseg.transformers.postprocess` and `rankseg.transformers.restore_semantic_probs`

### 4. Test coverage

This PR adds `tests/test_transformers.py` to cover:

- supported output restoration paths
- DETR / Conditional DETR branching
- Mask2Former and SAM3 behavior alignment
- explicit failure cases for unsupported output structures
- default `postprocess(...)` behavior

## Validation

I validated this work locally with:

- `uv run --with pytest --with torchmetrics --with scipy python -m pytest -o addopts='' tests/test_transformers.py`
- `uv run --with-requirements doc/requirements.txt sphinx-build -b html doc/source /tmp/rankseg-docs`

## Note

A small number of notebook and Colab links currently point to my fork to keep the demo runnable during PR review. These can be updated to the upstream repository after merge.
