### PR TITLE
docs: improve integration tutorial flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 
 # AI plan
 /.kilo
+/.agents
 
 # C extensions
 *.so
@@ -105,7 +106,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-#uv.lock
+uv.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -190,6 +190,12 @@ Learn More
 
       Maintained integration guides for PyTorch, Transformers, and SAM
 
+   .. grid-item-card:: 📓 Executable Notebooks
+      :link: notebooks
+      :link-type: doc
+
+      Notebook tutorials for quickstart, Transformers, SAM, and PaddleSeg
+
    .. grid-item-card:: 📚 API Reference
       :link: API
       :link-type: doc
@@ -217,6 +223,7 @@ References
 
    getting_started
    integrations
+   notebooks
    metrics
    citation
    API

--- a/doc/source/integrations.rst
+++ b/doc/source/integrations.rst
@@ -2,11 +2,118 @@ Official Integrations
 =====================
 
 RankSEG is designed to fit into existing inference pipelines with minimal code
-changes. This section collects the maintained integration paths officially
-documented in this repository.
+changes. Every integration page in this section answers the same practical
+question:
+
+   Given a trained segmentation model, where do I replace the usual
+   ``argmax`` or ``0.5`` threshold with ``RankSEG``?
+
+The common insertion point is:
+
+.. code-block:: text
+
+   image -> model -> logits/probabilities -> RankSEG -> prediction mask
+
+For multiclass semantic segmentation, the model usually returns logits with
+shape ``(B, C, H, W)``. Convert them to probabilities with ``softmax`` before
+calling RankSEG. RankSEG then produces the final mask for the metric you care
+about, such as Dice or IoU.
+
+For multilabel segmentation, replace ``softmax`` with ``sigmoid`` and use
+``output_mode="multilabel"``.
+
+Inputs and outputs
+------------------
+
+.. list-table::
+   :widths: 24 34 42
+   :header-rows: 1
+
+   * - Item
+     - Code object
+     - What to check
+   * - Model scores
+     - ``logits``
+     - Tensor of shape ``(B, C, *image_shape)`` before activation.
+   * - Probability map
+     - ``probs``
+     - Tensor in ``[0, 1]`` with shape ``(B, C, *image_shape)``.
+   * - Target metric
+     - ``RankSEG(metric=...)``
+     - ``"dice"``, ``"iou"``, or ``"acc"``.
+   * - Prediction family
+     - ``output_mode``
+     - ``"multiclass"`` returns one class index per pixel; ``"multilabel"``
+       returns one binary mask per class.
+   * - Solver
+     - ``solver``
+     - ``"RMA"`` is the recommended default for Dice/IoU inference.
+   * - Final prediction
+     - ``preds = rankseg.predict(probs)``
+     - Tensor consumed by your evaluator or visualization code.
 
 Available integrations
 ----------------------
+
+.. list-table::
+   :widths: 18 27 27 28
+   :header-rows: 1
+
+   * - Backend
+     - Best starting point
+     - Where RankSEG is called
+     - Executable tutorial
+   * - PyTorch Native
+     - You already own the model forward pass.
+     - ``RankSEG(...).predict(probs)``
+     - `quickstart.ipynb <https://github.com/rankseg/rankseg/blob/main/notebooks/quickstart.ipynb>`__
+   * - Transformers
+     - You use Hugging Face semantic segmentation through
+       ``processor -> model -> outputs``.
+     - ``rankseg.integration.transformers.postprocess(...)``
+     - `rankseg_with_transformers.ipynb <https://github.com/rankseg/rankseg/blob/main/notebooks/rankseg_with_transformers.ipynb>`__
+   * - SAM Family
+     - You use SAM1, SAM2, or SAM3 outputs from Hugging Face Transformers.
+     - ``sam.Sam1`` / ``sam.Sam2`` / ``sam.Sam3`` adapters
+     - `rankseg_with_sam_family.ipynb <https://github.com/rankseg/rankseg/blob/main/notebooks/rankseg_with_sam_family.ipynb>`__
+   * - PaddleSeg
+     - You use PaddleSeg and can work from the external integration branch.
+     - Convert Paddle probabilities to a PyTorch tensor, then call RankSEG.
+     - `rankseg_with_paddleseg.ipynb <https://github.com/rankseg/rankseg/blob/main/notebooks/rankseg_with_paddleseg.ipynb>`__
+
+Choose your path
+----------------
+
+- Start with :doc:`integrations_pytorch` if your inference code already
+  exposes logits or probabilities as PyTorch tensors.
+- Start with :doc:`integrations_transformers` if you want to keep the standard
+  Hugging Face ``processor -> model -> outputs`` workflow unchanged.
+- Start with :doc:`integrations_sam` for SAM-family models, because SAM
+  outputs include family-specific geometry restoration before the final mask
+  step.
+- Start with :doc:`integrations_paddleseg` only when your deployment is already
+  in PaddleSeg. It is currently linked as an external/community-maintained
+  integration path.
+
+Recommended defaults
+--------------------
+
+For ordinary semantic segmentation, the first configuration to try is:
+
+.. code-block:: python
+
+   from rankseg import RankSEG
+
+   rankseg = RankSEG(metric="dice", solver="RMA", output_mode="multiclass")
+   preds = rankseg.predict(probs)
+
+This setup targets the Dice metric, uses the efficient RMA solver, and returns
+one non-overlapping class label per pixel. Change the metric only when your
+evaluation protocol uses a different metric, and change ``output_mode`` only
+when your task allows overlapping class masks.
+
+Tutorial pages
+--------------
 
 .. toctree::
    :maxdepth: 1
@@ -16,15 +123,20 @@ Available integrations
    integrations_sam
    integrations_paddleseg
 
-Guiding principle
------------------
+Common mistakes
+---------------
 
-At the integration layer, the goal is to help users adopt RankSEG in the
-framework they already use.
+- Passing raw logits directly to ``RankSEG``. Use ``softmax`` for multiclass
+  probabilities or ``sigmoid`` for multilabel probabilities first.
+- Mixing output semantics. ``output_mode="multiclass"`` returns
+  ``(B, *image_shape)`` class-index masks, while ``output_mode="multilabel"``
+  returns ``(B, C, *image_shape)`` binary masks.
+- Using SAM outputs with the generic Transformers helper. SAM-family models
+  require the explicit adapters documented in :doc:`integrations_sam`.
+- Comparing against a dataset-level Dice definition without checking
+  aggregation. RankSEG targets the samplewise metric convention explained in
+  :doc:`metrics`.
 
-Solver details such as ``RMA`` remain part of the recommended configuration
-inside each integration page, rather than the top-level navigation label.
-
-At the moment, ``PyTorch Native``, ``Transformers``, and ``SAM Family`` are
-the first-party maintained entry points documented here, while ``PaddleSeg`` is
-provided as an external/community-maintained path.
+The API reference remains available at :doc:`API`, but these integration pages
+are the intended tutorial entry points for applying RankSEG in real inference
+code.

--- a/doc/source/integrations_paddleseg.rst
+++ b/doc/source/integrations_paddleseg.rst
@@ -12,6 +12,31 @@ outside the main ``rankseg`` branch.
 At this stage, the main repository provides an entry point to that work rather
 than duplicating or re-implementing the full PaddleSeg integration locally.
 
+How it fits the RankSEG integration pattern
+-------------------------------------------
+
+The insertion point is the same as the first-party integrations:
+
+.. code-block:: text
+
+   PaddleSeg model -> probability map -> convert to PyTorch tensor
+   -> RankSEG -> prediction mask
+
+The difference is maintenance scope. RankSEG's public predictor currently
+expects a PyTorch tensor, so Paddle outputs need an explicit conversion step
+before calling ``RankSEG.predict``.
+
+.. code-block:: python
+
+   import torch
+   from rankseg import RankSEG
+
+   # probs_paddle has shape (batch_size, num_classes, height, width)
+   probs = torch.from_numpy(probs_paddle.numpy())
+
+   rankseg = RankSEG(metric="dice", solver="RMA", output_mode="multiclass")
+   preds = rankseg.predict(probs)
+
 Who should use this path
 ------------------------
 
@@ -29,6 +54,8 @@ Available entry points
   `Leev1s/rankseg (paddleseg branch) <https://github.com/Leev1s/rankseg/tree/paddleseg/rankseg/paddleseg>`_
 - Docker image:
   `ghcr.io/leev1s/rankseg <https://ghcr.io/leev1s/rankseg>`_
+- Notebook:
+  `notebooks/rankseg_with_paddleseg.ipynb <https://github.com/rankseg/rankseg/blob/main/notebooks/rankseg_with_paddleseg.ipynb>`_
 
 Scope and maintenance
 ---------------------

--- a/doc/source/integrations_pytorch.rst
+++ b/doc/source/integrations_pytorch.rst
@@ -12,6 +12,22 @@ If you already have a PyTorch semantic-segmentation model and want to replace
 ``argmax`` with a better inference-time post-processing step, this is the
 recommended starting point.
 
+Where RankSEG fits
+------------------
+
+Most PyTorch segmentation code has three stages:
+
+.. code-block:: text
+
+   images -> model(images) -> logits -> argmax/threshold -> masks
+
+RankSEG keeps the model and logits unchanged. The only change is the final
+prediction step:
+
+.. code-block:: text
+
+   images -> model(images) -> logits -> probabilities -> RankSEG -> masks
+
 The default official configuration is:
 
 .. code-block:: python
@@ -24,6 +40,9 @@ different metric or output mode.
 
 Minimal integration
 -------------------
+
+If your model already returns a logits tensor, the integration is only a few
+lines:
 
 .. code-block:: python
 
@@ -38,6 +57,69 @@ Minimal integration
        rankseg = RankSEG(metric="dice", solver="RMA", output_mode="multiclass")
        preds = rankseg.predict(probs)      # (batch_size, *image_shape)
 
+Usual PyTorch inference vs RankSEG inference
+--------------------------------------------
+
+This example is self-contained and uses a tiny convolutional model only to show
+the tensor contract. Replace ``model`` with your trained network.
+
+.. code-block:: python
+
+   import torch
+   from rankseg import RankSEG
+
+   model = torch.nn.Conv2d(in_channels=3, out_channels=21, kernel_size=1)
+   images = torch.randn(2, 3, 256, 256)
+
+   model.eval()
+   with torch.inference_mode():
+       logits = model(images)
+       probs = torch.softmax(logits, dim=1)
+
+       baseline_preds = probs.argmax(dim=1)
+
+       rankseg = RankSEG(metric="dice", solver="RMA", output_mode="multiclass")
+       rankseg_preds = rankseg.predict(probs)
+
+   print("logits:  ", tuple(logits.shape))          # (2, 21, 256, 256)
+   print("baseline:", tuple(baseline_preds.shape))  # (2, 256, 256)
+   print("RankSEG: ", tuple(rankseg_preds.shape))   # (2, 256, 256)
+
+Choosing options
+----------------
+
+.. list-table::
+   :widths: 22 34 44
+   :header-rows: 1
+
+   * - Option
+     - Recommended starting value
+     - When to change it
+   * - ``metric``
+     - ``"dice"``
+     - Use ``"iou"`` when your benchmark or report is IoU-centered.
+   * - ``solver``
+     - ``"RMA"``
+     - Start here for Dice/IoU. Use other solvers only when you need their specific trade-offs.
+   * - ``output_mode``
+     - ``"multiclass"``
+     - Use ``"multilabel"`` when the final masks may overlap.
+   * - Activation before RankSEG
+     - ``torch.softmax(logits, dim=1)``
+     - Use ``torch.sigmoid(logits)`` for independent multilabel probabilities.
+
+Notebook and script
+-------------------
+
+For a notebook-style walkthrough with a pretrained model, see:
+
+- `notebooks/quickstart.ipynb <https://github.com/rankseg/rankseg/blob/main/notebooks/quickstart.ipynb>`_
+- `Open in Colab <https://colab.research.google.com/github/rankseg/rankseg/blob/main/notebooks/quickstart.ipynb>`_
+
+The maintained script version is:
+
+- `examples/pytorch_native_rankseg.py <https://github.com/rankseg/rankseg/blob/main/examples/pytorch_native_rankseg.py>`_
+
 For a more complete explanation of:
 
 - probability conventions
@@ -47,10 +129,3 @@ For a more complete explanation of:
 - common integration mistakes
 
 see :doc:`getting_started`.
-
-Official example
-----------------
-
-See the maintained example script:
-
-- `examples/pytorch_native_rankseg.py <https://github.com/rankseg/rankseg/blob/main/examples/pytorch_native_rankseg.py>`_

--- a/doc/source/integrations_sam.rst
+++ b/doc/source/integrations_sam.rst
@@ -7,9 +7,66 @@ Hugging Face ``transformers``.
 SAM-family outputs use explicit adapter classes instead of the standard
 Transformers semantic-segmentation helper.
 
+Why SAM has its own adapters
+----------------------------
+
+SAM outputs are not plain semantic-segmentation logits. Before RankSEG is
+called, SAM masks must be restored from model space back to image space using
+family-specific geometry:
+
+.. code-block:: text
+
+   SAM processor -> SAM model outputs -> restore mask probabilities
+   -> RankSEG -> prompt, instance, or semantic masks
+
+The adapters in ``rankseg.integration.sam`` keep this restoration step
+explicit. RankSEG only replaces the final binary mask step after masks have
+been resized and converted to probabilities.
+
 .. code-block:: python
 
    from rankseg.integration import sam
+
+Adapter map
+-----------
+
+.. list-table::
+   :widths: 18 28 28 26
+   :header-rows: 1
+
+   * - Adapter
+     - Input family
+     - Main prediction method
+     - Probability-only method
+   * - ``sam.Sam1``
+     - SAM1 and SAM-HQ prompt masks
+     - ``postprocess(...)``
+     - ``restore_mask_probs(...)``
+   * - ``sam.Sam2``
+     - SAM2 prompt masks
+     - ``postprocess(...)``
+     - ``restore_mask_probs(...)``
+   * - ``sam.Sam3``
+     - SAM3 instance masks
+     - ``postprocess_instance(...)``
+     - ``restore_instance_mask_probs(...)``
+   * - ``sam.Sam3``
+     - SAM3 semantic masks
+     - ``postprocess_semantic(...)``
+     - ``restore_semantic_mask_probs(...)``
+
+Recommended RankSEG options
+---------------------------
+
+SAM prompt and instance masks are naturally represented as per-mask binary
+probability maps, so the adapters default to ``output_mode="multilabel"`` when
+``rankseg_kwargs`` does not specify an output mode.
+
+.. code-block:: python
+
+   adapter = sam.Sam1(
+       rankseg_kwargs={"metric": "dice", "solver": "RMA"}
+   )
 
 SAM1 prompt masks
 -----------------
@@ -22,6 +79,10 @@ SAM1 prompt masks
        original_sizes=inputs["original_sizes"],
        reshaped_input_sizes=inputs["reshaped_input_sizes"],
    )
+
+``original_sizes`` and ``reshaped_input_sizes`` should come from the SAM
+processor inputs. The adapter removes padding, resizes masks back to the
+original image size, applies ``sigmoid``, and then calls RankSEG.
 
 SAM2 prompt masks
 -----------------
@@ -37,6 +98,10 @@ SAM2 prompt masks
        original_sizes=inputs["original_sizes"],
    )
 
+Set ``apply_non_overlapping_constraints=True`` when you want lower-scoring
+overlapping SAM2 masks to be suppressed before converting logits to
+probabilities.
+
 SAM3 instance masks
 -------------------
 
@@ -47,6 +112,10 @@ SAM3 instance masks
        outputs,
        target_sizes=target_sizes,
    )
+
+The instance method returns one dictionary per image with ``scores``, ``boxes``,
+and ``masks``. ``threshold`` filters low-confidence instances before RankSEG is
+applied to the remaining mask probabilities.
 
 SAM3 semantic masks
 -------------------
@@ -61,8 +130,31 @@ SAM3 semantic masks
 
 The SAM adapters follow the official Transformers post-processing order
 through geometry and score restoration. RankSEG replaces the final binary mask
-decision. For SAM3, callers choose ``postprocess_instance(...)`` or
+step. For SAM3, callers choose ``postprocess_instance(...)`` or
 ``postprocess_semantic(...)`` explicitly.
+
+Shape conventions
+-----------------
+
+.. list-table::
+   :widths: 28 34 38
+   :header-rows: 1
+
+   * - Stage
+     - Typical shape
+     - Meaning
+   * - Restored SAM prompt probabilities
+     - ``(num_masks, 1, H, W)`` or compatible per-image tensors
+     - One probability map per proposed prompt mask.
+   * - Restored SAM3 instance probabilities
+     - ``(num_instances, H, W)``
+     - One probability map per retained instance.
+   * - RankSEG prompt predictions
+     - Binary mask tensors matching restored mask geometry
+     - Final prompt masks after RankSEG post-processing.
+   * - RankSEG semantic predictions
+     - One tensor per image
+     - Final semantic masks from SAM3 semantic probabilities.
 
 Restored probabilities
 ----------------------
@@ -103,3 +195,14 @@ Current exclusions
 ------------------
 
 The SAM integration does not currently support SAM video tracker state.
+
+Executable tutorial
+-------------------
+
+The SAM-family notebook is the recommended way to learn this integration. It
+runs SAM1, SAM2, and SAM3 examples in separate sections, compares the official
+post-processing path with the RankSEG path, and keeps the model outputs shared
+between the two paths so the replacement point is visible.
+
+- `notebooks/rankseg_with_sam_family.ipynb <https://github.com/rankseg/rankseg/blob/main/notebooks/rankseg_with_sam_family.ipynb>`_
+- `Open in Colab <https://colab.research.google.com/github/rankseg/rankseg/blob/main/notebooks/rankseg_with_sam_family.ipynb>`_

--- a/doc/source/integrations_transformers.rst
+++ b/doc/source/integrations_transformers.rst
@@ -6,7 +6,21 @@ This page documents the RankSEG integration path for standard Hugging Face
 
 Use this path when you already run inference through a standard
 ``processor -> model -> outputs`` workflow and want RankSEG to replace the
-final ``argmax``-style decision step.
+final ``argmax``-style prediction step.
+
+Where RankSEG fits
+------------------
+
+Hugging Face segmentation models do not all expose the same raw tensor field.
+Some return ``outputs.logits``; query-based models return class-query and mask
+logits; some processors also own model-specific resizing logic. The RankSEG
+Transformers helper keeps the official inference flow intact and handles the
+last post-processing step:
+
+.. code-block:: text
+
+   processor(images) -> model(**inputs) -> restore semantic probabilities
+   -> RankSEG -> prediction masks
 
 .. code-block:: python
 
@@ -29,6 +43,35 @@ Its role is intentionally narrow:
 - restore probabilities from supported Hugging Face output families;
 - resize them to the original image size when needed;
 - apply ``RankSEG`` as the final post-processing step.
+
+Helper arguments
+----------------
+
+.. list-table::
+   :widths: 22 34 44
+   :header-rows: 1
+
+   * - Argument or return
+     - Shape or type
+     - Meaning
+   * - ``outputs``
+     - Structured Transformers output
+     - The object returned by ``model(**inputs)``. Tuple-style
+       ``return_dict=False`` outputs are intentionally unsupported.
+   * - ``model``
+     - Optional Transformers model
+     - Required for output families whose semantic reconstruction depends on
+       the model configuration.
+   * - ``target_sizes``
+     - List or tensor of ``(height, width)`` pairs
+     - One original output size per image. For a PIL image, use
+       ``[image.size[::-1]]``.
+   * - ``rankseg_kwargs``
+     - ``dict`` forwarded to ``RankSEG``
+     - Example: ``{"metric": "dice", "solver": "RMA"}``.
+   * - Return value
+     - ``list[torch.Tensor]``
+     - One predicted mask per input image.
 
 Minimal integration
 -------------------
@@ -58,9 +101,40 @@ integration change happens after ``outputs = model(**inputs)``.
 
 For supported output families, ``transformers.postprocess(...)`` preserves the
 surrounding Hugging Face inference code and replaces only the final prediction
-decision. SAM-family outputs are intentionally handled by ``sam.Sam1``,
+step. SAM-family outputs are intentionally handled by ``sam.Sam1``,
 ``sam.Sam2``, or ``sam.Sam3`` after ``from rankseg.integration import sam``
 instead of this helper.
+
+Compare with the usual argmax step
+----------------------------------
+
+The usual SegFormer-style baseline is:
+
+.. code-block:: python
+
+   import torch.nn.functional as F
+
+   upsampled_logits = F.interpolate(
+       outputs.logits,
+       size=image.size[::-1],
+       mode="bilinear",
+       align_corners=False,
+   )
+   baseline_pred = upsampled_logits.argmax(dim=1)[0]
+
+The RankSEG version asks the helper to restore probabilities and then produce
+the final prediction:
+
+.. code-block:: python
+
+   rankseg_pred = transformers.postprocess(
+       outputs,
+       target_sizes=[image.size[::-1]],
+       rankseg_kwargs={"metric": "dice", "solver": "RMA"},
+   )[0]
+
+This is the intended replacement point: the processor, model, checkpoint, and
+input preparation remain unchanged.
 
 Advanced probability helper
 ---------------------------
@@ -100,6 +174,29 @@ output families used by ``transformers``:
 When a branch requires model-specific handling, pass ``model=...`` so the
 helper can follow the corresponding official post-processing behavior.
 
+Output defaults
+---------------
+
+If ``rankseg_kwargs`` omits ``output_mode``, the helper chooses:
+
+- ``"multiclass"`` when the restored semantic probability map has more than
+  one class channel;
+- ``"multilabel"`` when the restored probability map has one channel.
+
+You can override this explicitly:
+
+.. code-block:: python
+
+   preds = transformers.postprocess(
+       outputs,
+       target_sizes=[image.size[::-1]],
+       rankseg_kwargs={
+           "metric": "dice",
+           "solver": "RMA",
+           "output_mode": "multiclass",
+       },
+   )
+
 Current exclusions
 ------------------
 
@@ -114,3 +211,17 @@ The simplified API does not currently support:
 
 These cases should fail explicitly rather than silently using an incorrect
 semantic restoration path.
+
+Executable tutorial
+-------------------
+
+The notebook below is written as a user-facing tutorial: it first runs the
+official Hugging Face baseline, then repeats the same inference flow with only
+the final post-processing step replaced by RankSEG.
+
+- `notebooks/rankseg_with_transformers.ipynb <https://github.com/rankseg/rankseg/blob/main/notebooks/rankseg_with_transformers.ipynb>`_
+- `Open in Colab <https://colab.research.google.com/github/rankseg/rankseg/blob/main/notebooks/rankseg_with_transformers.ipynb>`_
+
+The maintained script version is:
+
+- `examples/transformers_rankseg.py <https://github.com/rankseg/rankseg/blob/main/examples/transformers_rankseg.py>`_

--- a/doc/source/notebooks.rst
+++ b/doc/source/notebooks.rst
@@ -1,0 +1,48 @@
+Executable Notebooks
+====================
+
+These notebooks are maintained as user-facing tutorials. They are intended to
+be run from top to bottom and to show the exact point where RankSEG replaces a
+standard segmentation prediction step.
+
+.. list-table::
+   :widths: 24 42 34
+   :header-rows: 1
+
+   * - Notebook
+     - What it teaches
+     - Best entry point
+   * - `quickstart.ipynb <https://github.com/rankseg/rankseg/blob/main/notebooks/quickstart.ipynb>`__
+     - A short PyTorch walkthrough with a pretrained DeepLabV3-style workflow:
+       model output, probability map, baseline mask, RankSEG mask.
+     - New users who want the fastest runnable example.
+   * - `rankseg_with_transformers.ipynb <https://github.com/rankseg/rankseg/blob/main/notebooks/rankseg_with_transformers.ipynb>`__
+     - A Hugging Face tutorial that first runs the official baseline and then
+       changes only the final post-processing step to RankSEG.
+     - Users with ``processor -> model -> outputs`` code.
+   * - `rankseg_with_sam_family.ipynb <https://github.com/rankseg/rankseg/blob/main/notebooks/rankseg_with_sam_family.ipynb>`__
+     - A SAM-family tutorial covering SAM1, SAM2, and SAM3 adapters, including
+       geometry restoration before RankSEG is called.
+     - Users working with prompt, instance, or semantic masks from SAM-family
+       models.
+   * - `rankseg_with_paddleseg.ipynb <https://github.com/rankseg/rankseg/blob/main/notebooks/rankseg_with_paddleseg.ipynb>`__
+     - A PaddleSeg-oriented walkthrough that shows the probability conversion
+       step before calling the PyTorch-based RankSEG predictor.
+     - PaddleSeg users evaluating the external/community-maintained path.
+
+Colab links
+-----------
+
+- `Open quickstart.ipynb in Colab <https://colab.research.google.com/github/rankseg/rankseg/blob/main/notebooks/quickstart.ipynb>`_
+- `Open rankseg_with_transformers.ipynb in Colab <https://colab.research.google.com/github/rankseg/rankseg/blob/main/notebooks/rankseg_with_transformers.ipynb>`_
+- `Open rankseg_with_sam_family.ipynb in Colab <https://colab.research.google.com/github/rankseg/rankseg/blob/main/notebooks/rankseg_with_sam_family.ipynb>`_
+- `Open rankseg_with_paddleseg.ipynb in Colab <https://colab.research.google.com/github/rankseg/rankseg/blob/main/notebooks/rankseg_with_paddleseg.ipynb>`_
+
+How to read the notebooks with the docs
+---------------------------------------
+
+Use :doc:`integrations` first to choose the correct backend. Then open the
+matching notebook when you want a runnable, visual workflow. The conceptual
+pages define the tensor shapes, probability conventions, option names, and
+supported output families; the notebooks show those contracts in complete
+inference code.


### PR DESCRIPTION
Clarify the RankSEG documentation path from overview to backend-specific tutorials so users can see where post-processing fits in existing segmentation pipelines.

Add notebook navigation, expand integration pages with practical input/output and option guidance.

Update .gitignore to exclude local agent configuration and uv lock artifacts.