### PR TITLE
Fix zero for unassigned pixels in rankseg-rma.

### DIFF
--- a/rankseg/_rankseg.py
+++ b/rankseg/_rankseg.py
@@ -66,7 +66,9 @@ class RankSEG(object):
     \*\*solver_params : dict
         Additional parameters passed to the specific solver.
         For 'BA', 'TRNA' or 'BA+TRNA': eps (1 - confidence intervals for refined
-        normal approximation of poisson-binomial distributions)
+        normal approximation of poisson-binomial distributions).
+        For 'RMA': unassigned_policy and void_index control multiclass output
+        for pixels not selected as positive by any class.
 
     References
     ----------

--- a/rankseg/_rankseg_algo.py
+++ b/rankseg/_rankseg_algo.py
@@ -214,6 +214,8 @@ def rankseg_rma(
     smooth: float = 0.0,
     output_mode: str = "multiclass",
     pruning_prob: float = 0.5,
+    unassigned_policy: str = "max_score",
+    void_index: int = 255,
 ) -> torch.Tensor:
     r"""
     Produce the predicted segmentation by `rankdice` based on the estimated output probability.
@@ -238,6 +240,29 @@ def rankseg_rma(
         The threshold for pruning, if all probabilities are less than `pruning_prob`,
         we skip the class.
 
+    unassigned_policy : {'max_score', 'void'}, default='max_score'
+        Policy for pixels that are not selected as positive by any class when
+        converting individual binary masks to a multiclass prediction.
+
+        RankSEG-RMA first builds one binary mask per class. In multiclass mode,
+        a pixel can then be:
+        - selected by exactly one class, in which case that class is used;
+        - selected by multiple classes, in which case the class with the largest
+          incremental score is used;
+        - selected by no class, in which case this policy is used.
+
+        If 'max_score', unassigned pixels are assigned to the class with the
+        largest incremental score, as with pixels selected by multiple classes.
+
+        If 'void', unassigned pixels are assigned to `void_index`.
+
+    void_index : int, default=255
+        Label used for unassigned pixels when `unassigned_policy == 'void'`.
+
+        The default value, 255, is a prediction-level abstention label. Note
+        that this can make predictions contain labels outside the normal class
+        space.
+
     Returns
     -------
     preds : Tensor
@@ -251,10 +276,15 @@ def rankseg_rma(
 
     metric = metric.strip().lower() if isinstance(metric, str) else metric
     output_mode = output_mode.strip().lower() if isinstance(output_mode, str) else output_mode
+    unassigned_policy = unassigned_policy.strip().lower() if isinstance(unassigned_policy, str) else unassigned_policy
     if metric not in ["iou", "dice"]:
         raise ValueError("metric should be iou or dice")
     if output_mode not in ["multiclass", "multilabel"]:
         raise ValueError("output_mode should be multiclass or multilabel")
+    if unassigned_policy not in ["max_score", "void"]:
+        raise ValueError("unassigned_policy should be max_score or void")
+    if not isinstance(void_index, int):
+        raise TypeError("void_index must be an int")
 
     def compute_opt_tau(
         metric: str,
@@ -289,13 +319,16 @@ def rankseg_rma(
         pb_mean: torch.Tensor,
         smooth: float,
         pruning_prob: float,
+        unassigned_policy: str,
+        void_index: int,
     ) -> torch.Tensor:
         batch_size, num_classes, dim = probs.size()
 
         class_counts = overlap_preds.sum(dim=1)
+        unassigned_mask = class_counts == 0
         single_pred_mask = class_counts == 1
         overlap_mask = class_counts > 1
-        safe_to_predict = overlap_preds & ~overlap_mask.unsqueeze(1)
+        safe_to_predict = overlap_preds & single_pred_mask.unsqueeze(1)
 
         mu = (probs * safe_to_predict.float()).sum(dim=2, keepdim=True)
         opt_tau = safe_to_predict.float().sum(dim=2, keepdim=True)
@@ -314,11 +347,13 @@ def rankseg_rma(
         )
 
         increment_argmax_mask = increment_scores.argmax(dim=1)
-        nonoverlap_predicts = torch.zeros((batch_size, dim), dtype=torch.int16, device=device)
-        nonoverlap_predicts[single_pred_mask] = (
-            overlap_preds.to(torch.int16).argmax(dim=1).to(torch.int16)[single_pred_mask]
-        )
-        nonoverlap_predicts[overlap_mask] = increment_argmax_mask[overlap_mask].to(torch.int16)
+        nonoverlap_predicts = torch.zeros((batch_size, dim), dtype=torch.long, device=device)
+        nonoverlap_predicts[single_pred_mask] = overlap_preds.long().argmax(dim=1)[single_pred_mask]
+        nonoverlap_predicts[overlap_mask] = increment_argmax_mask[overlap_mask].long()
+        if unassigned_policy == "max_score":
+            nonoverlap_predicts[unassigned_mask] = increment_argmax_mask[unassigned_mask].long()
+        else:
+            nonoverlap_predicts[unassigned_mask] = void_index
 
         return nonoverlap_predicts
 
@@ -361,6 +396,8 @@ def rankseg_rma(
                 pb_mean,
                 smooth,
                 pruning_prob,
+                unassigned_policy,
+                void_index,
             )
         preds = nonoverlap_preds.reshape(batch_size, *image_shape)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -172,6 +172,35 @@ def test_rankseg_iou_invalid_solver_falls_back_to_rma(demo_data):
     assert torch.equal(preds, expected)
 
 
+def test_rankseg_rma_multiclass_void_unassigned_policy():
+    probs = torch.tensor(
+        [
+            [
+                [[0.95, 0.01, 0.01, 0.01]],
+                [[0.01, 0.95, 0.95, 0.10]],
+                [[0.01, 0.55, 0.55, 0.01]],
+            ]
+        ],
+        dtype=torch.float32,
+    )
+
+    rankseg = RankSEG(
+        metric="dice",
+        solver="RMA",
+        output_mode="multiclass",
+        pruning_prob=0.5,
+        unassigned_policy="void",
+        void_index=99,
+    )
+    preds = rankseg.predict(probs)
+
+    assert rankseg.solver_params["unassigned_policy"] == "void"
+    assert rankseg.solver_params["void_index"] == 99
+    assert not hasattr(rankseg, "unassigned_policy")
+    assert not hasattr(rankseg, "void_index")
+    assert torch.equal(preds, torch.tensor([[[0, 1, 1, 99]]]))
+
+
 def test_rankseg_metric_is_case_insensitive_for_dice(demo_data):
     probs, _ = demo_data
 

--- a/tests/test_rankseg_algo.py
+++ b/tests/test_rankseg_algo.py
@@ -50,6 +50,50 @@ def test_rankseg_rma_pruning_can_return_all_zero_masks():
     assert int(preds.sum().item()) == 0
 
 
+def test_rankseg_rma_multiclass_unassigned_policy_max_score():
+    probs = torch.tensor(
+        [
+            [
+                [[0.95, 0.01, 0.01, 0.01]],
+                [[0.01, 0.95, 0.95, 0.10]],
+                [[0.01, 0.55, 0.55, 0.01]],
+            ]
+        ],
+        dtype=torch.float32,
+    )
+
+    preds = rankseg_rma(probs, metric="dice", output_mode="multiclass", pruning_prob=0.5)
+
+    assert preds.shape == (1, 1, 4)
+    assert preds.dtype == torch.int64
+    assert torch.equal(preds[0, 0, :3], torch.tensor([0, 1, 1]))
+    assert preds[0, 0, 3].item() == 1
+
+
+def test_rankseg_rma_multiclass_unassigned_policy_void():
+    probs = torch.tensor(
+        [
+            [
+                [[0.95, 0.01, 0.01, 0.01]],
+                [[0.01, 0.95, 0.95, 0.10]],
+                [[0.01, 0.55, 0.55, 0.01]],
+            ]
+        ],
+        dtype=torch.float32,
+    )
+
+    preds = rankseg_rma(
+        probs,
+        metric="dice",
+        output_mode="multiclass",
+        pruning_prob=0.5,
+        unassigned_policy="void",
+        void_index=255,
+    )
+
+    assert torch.equal(preds, torch.tensor([[[0, 1, 1, 255]]]))
+
+
 def test_rankseg_rma_rejects_unknown_metric():
     probs = _demo_probs()
 
@@ -62,6 +106,13 @@ def test_rankseg_rma_rejects_unknown_output_mode():
 
     with pytest.raises(ValueError, match="output_mode should be multiclass or multilabel"):
         rankseg_rma(probs, metric="dice", output_mode="overlap")
+
+
+def test_rankseg_rma_rejects_unknown_unassigned_policy():
+    probs = _demo_probs()
+
+    with pytest.raises(ValueError, match="unassigned_policy should be max_score or void"):
+        rankseg_rma(probs, metric="dice", output_mode="multiclass", unassigned_policy="ignore")
 
 
 def test_rankdice_ba_trna_returns_binary_masks():


### PR DESCRIPTION
This PR fixes #18 by explicitly handling pixels that are not selected as positive by any class in RankSEG-RMA multiclass output.

Previously, `convert_to_nonoverlap` only handled two cases:

1. pixels selected by exactly one class;
2. pixels selected by multiple classes.

Pixels selected by no class were left at the initialized value `0`, which could introduce an unintended class-0 fallback. This made RankSEG predictions contain classes that were not selected by the RMA positive masks, and could lead to one extra unique class compared with argmax.

## Changes

This PR adds explicit handling for the unassigned set:

- `class_counts == 1`: keep the uniquely selected class;
- `class_counts > 1`: assign the class with the largest incremental score;
- `class_counts == 0`: handle according to the new `unassigned_policy`.

Two policies are supported in `rankseg_rma`:

- `unassigned_policy="max_score"`: assign unassigned pixels to the class with the largest incremental score.
  This is the default because it keeps predictions inside the normal class label space.

- `unassigned_policy="void"`: assign unassigned pixels to `void_index`, defaulting to `255`.
  This represents a prediction-level abstention / void label. Users should note that this can make predictions contain labels outside the normal class space.

The new arguments are RMA-specific and can be passed through `RankSEG(..., **solver_params)`.

## Benchmark

The new policies slightly improve the metrics by fixing unintended class-`0` predictions:

| Dataset | Metric | argmax | rankseg-RMA | max_score | void |
|---|---:|---:|---:|---:|---:|
| Pascal VOC | mDice | 91.02 | 91.46 | 91.47 | 91.47 |
| Pascal VOC | mIoU | 87.80 | 88.23 | 88.23 | 88.24 |
| Cityscapes | mDice | 82.62 | 83.23 | 83.23 | 83.25 |
| Cityscapes | mIoU | 75.67 | 76.19 | 76.20 | 76.22 |
| ADE20K | mDice | 63.98 | 64.92 | 64.96 | 64.96 |
| ADE20K | mIoU | 56.95 | 57.67 | 57.72 | 57.74 |